### PR TITLE
Feature/Templates

### DIFF
--- a/.git-commit.template
+++ b/.git-commit.template
@@ -1,0 +1,11 @@
+#### Uncomment the line with the commit type below and add 7+ word description
+#wip: 
+
+#fix: 
+#feature: 
+
+#doc: 
+#poc: 
+
+#refactor: 
+#debt: 

--- a/.git-commit.template
+++ b/.git-commit.template
@@ -1,4 +1,4 @@
-#### Uncomment the line with the commit type below and add 7+ word description
+#### Uncomment the line with the commit type below and add 5+ word description
 #wip: 
 
 #fix: 

--- a/.git-commit.types
+++ b/.git-commit.types
@@ -1,0 +1,8 @@
+wip
+feature
+feat
+fix
+doc
+refactor
+debt
+poc

--- a/.github/ISSUES/bugfix.md
+++ b/.github/ISSUES/bugfix.md
@@ -1,0 +1,14 @@
+## Description
+Please describe the issue or bug and how you found it
+
+## Expected Result
+Describe what you expected to happen
+
+## Actual Result
+Describe what actually occured that caused you to notice this
+
+## How to
+If this bug is reproducible please provide the exact steps to reproduce below
+
+## Visual
+If you can capture an image, please provide one

--- a/.github/ISSUES/doc.md
+++ b/.github/ISSUES/doc.md
@@ -1,0 +1,5 @@
+## Description
+Describe the documentation that is being requested
+
+## References
+Provide examples or resources that will be helpful in generating the requested documentation

--- a/.github/ISSUES/feature.md
+++ b/.github/ISSUES/feature.md
@@ -1,0 +1,8 @@
+## Description 
+A clear and concise description of the new feature, and how you think it should be accomplished.
+
+## Acceptance Criteria 
+Describe how we will know this task is complete
+
+## Alternatives (Optional) 
+Please describe and alternative solution or features you've considered

--- a/.github/ISSUES/poc.md
+++ b/.github/ISSUES/poc.md
@@ -1,0 +1,5 @@
+## Description
+A brief description of the Proof of Concept/Research needed
+
+## Stakeholders
+List the people/organizations intereseted in this being completed

--- a/.github/ISSUES/techdebt.md
+++ b/.github/ISSUES/techdebt.md
@@ -1,0 +1,11 @@
+## Description
+Describe the upgrade/enhancment that you would like completed
+
+## Steps
+Please detail how this should be done
+
+## Resources
+[Link]() to any resources/articles that would be useful for this task
+
+## Warnings
+Any suggestions or tips that will help in the upgrade?

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+*.swp
 .gitfetch
 node_modules

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ Testing githooks, started with `pre-commit`, and then added script for `prepare-
     - `.git/COMMIT_EDITMSG message` when using -m with `git commit` 
 
  - githooks environment variables
-  - https://longair.net/blog/2011/04/09/missing-git-hooks-documentation/
+    - https://longair.net/blog/2011/04/09/missing-git-hooks-documentation/
 
  - Linear Git History
-  - https://www.bitsnbites.eu/a-tidy-linear-git-history/
-  - shouldn't merge from master (TODO: create githook that prevents this?)
-  - Git action that checks PRs to be rebased off most recent master
-  - more important when multiple contributors on a project
+   - https://www.bitsnbites.eu/a-tidy-linear-git-history/
+   - shouldn't merge from master (TODO: create githook that prevents this?)
+   - Git action that checks PRs to be rebased off most recent master
+   - more important when multiple contributors on a project
 
  - Setting up branch protections
     - https://github.com/devlinjunker/test.husky/settings/branches to add rules
@@ -54,7 +54,7 @@ Testing githooks, started with `pre-commit`, and then added script for `prepare-
       - doc ?
       - poc ? - proof of concept
 
- - Templates
+ - Templates [done]
     - commit.template config in repo to reference commit message template
       - wip/feature/fix/refactor(component)/doc - look into other options in angular style
     - Github PR template

--- a/README.md
+++ b/README.md
@@ -56,22 +56,20 @@ Testing githooks, started with `pre-commit`, and then added script for `prepare-
 
  - Templates
     - commit.template config in repo to reference commit message template
+      - wip/feature/fix/refactor(component)/doc - look into other options in angular style
     - Github PR template
     - Github Issue template
 
  - Before all Commits:
     - Lint
     - Compile
-    - don't allow commits with -m option
-      - or request type if not present? (fix/feat/refactor/wip?)
-
- - Commit Message Template?
-    - wip/feature/fix/refactor(component)/doc - look into other options in angular style
+    - ~~Don't allow commits with -m option?~~
+      - or verify ~~request~~ type if not present? (fix/feat/refactor/wip?)
 
  - After Commit Message:
-    - Verify message contains component above and 7+ words
-    - spell check?
-    - don't test on wip
+    - Verify message contains component above and 5+ words
+    - TODO: spell check?
+    - don't test on wip?
 
  - After non-master/release commit
     - check up to date with master and encourage rebase

--- a/package.json
+++ b/package.json
@@ -27,8 +27,6 @@
   },
 	"husky": {
 		"hooks": {
-			"pre-commit": "./scripts/test.sh test & echo 'USING HUSKY PRE-COMMIT WITH MESSAGE' &  exit 0 # exit 1 to fail commit",
-			"prepare-commit-msg": "./scripts/hooks/prepare-commit-msg.sh",
       "commit-msg": "./scripts/hooks/commit-msg.sh"
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 	"husky": {
 		"hooks": {
 			"pre-commit": "./scripts/test.sh test & echo 'USING HUSKY PRE-COMMIT WITH MESSAGE' &  exit 0 # exit 1 to fail commit",
-			"prepare-commit-msg": "./scripts/test.sh $GIT_PARAMS; echo 'test'; echo $HUSKY_GIT_PARAMS",
+			"prepare-commit-msg": "./scripts/hooks/prepare-commit-msg.sh",
       "commit-msg": "./scripts/test.sh"
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"hooks": {
 			"pre-commit": "./scripts/test.sh test & echo 'USING HUSKY PRE-COMMIT WITH MESSAGE' &  exit 0 # exit 1 to fail commit",
 			"prepare-commit-msg": "./scripts/hooks/prepare-commit-msg.sh",
-      "commit-msg": "./scripts/test.sh"
+      "commit-msg": "./scripts/hooks/commit-msg.sh"
 		}
 	}
 }

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,15 +1,15 @@
-**Description**
+## :grey_question: Description
 
 
-:heavy_check_mark: **Testing**
+## :heavy_check_mark: Testing
 Unit test cases, edge cases, e2e/automated testing, etc.  
 
-:memo: **Documentation**
+## :memo: Documentation
 [Links]() to readmes, files, wiki, issues, websites, etc.
 
-:bulb: **Issues**
+## :bulb: Issues
 N/A 
 
-:camera_flash: **Visuals:**
+## :camera_flash: Visuals
 TBD
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,15 @@
+**Description**
+
+
+:heavy_check_mark: **Testing**
+Unit test cases, edge cases, e2e/automated testing, etc.  
+
+:memo: **Documentation**
+[Links]() to readmes, files, wiki, issues, websites, etc.
+
+:bulb: **Issues**
+N/A 
+
+:camera_flash: **Visuals:**
+TBD
+

--- a/scripts/hooks/commit-msg.sh
+++ b/scripts/hooks/commit-msg.sh
@@ -38,7 +38,7 @@ do
 
       # Has prefix to check
       if grep -q "$prefix" ".git-commit.types"; then
-        continue;
+        :
       else
         echo "
 
@@ -54,7 +54,7 @@ do
       fi 
 
       # TODO: Check number of words in message
-      if [[ $(echo $message | wc -w) -le 4 ]]; then
+      if [[ $(echo "$message" | wc -w) -le 4 ]]; then
         echo "
 
         Error: Message should be 5+ words (but really you should add as much detail as possible)

--- a/scripts/hooks/commit-msg.sh
+++ b/scripts/hooks/commit-msg.sh
@@ -1,5 +1,6 @@
 #! /bin/bash
 
+values=`cat .git-commit.types | tr '\n' '|' | sed 's/.$//'`;
 first=true;
 
 # Parse message from commit message file (location passed with $HUSKY_GIT_PARAMS)
@@ -18,12 +19,27 @@ do
 
       hasPrefix=true;
       # TODO: if $prefix has spaces hasPrefix=false; and request prefix/type from user
+      # Seems like interacting with user is discouraged in githooks, so we'll just have to fail the commit and give message explaining how to fix
+#      if [[ "$prefix" =~ \  ]]; then
+#        hasprefix=false;
+#        echo "commit message missing prefix, enter one now ($values): ";
+#        read prefix;
+#        while [ -z $(cat ".git-commit.types" | grep "$prefix") ]
+#        do
+#          read prefix;
+#          if [[ $prefix = "q" ]]; then
+#            exit 1;
+#          fi
+#          if [ -z $(cat ".git-commit.types" | grep "$prefix") ]; then
+#            echo "prefix does not match, enter another ($values): ";
+#          fi
+#        done
+#      fi
 
       # Has prefix to check
       if grep -q "$prefix" ".git-commit.types"; then
         continue;
       else
-        values=`cat .git-commit.types | tr '\n' '|' | sed 's/.$//'`;
         echo "
 
         Error: Unexpected commit message prefix - $prefix
@@ -32,14 +48,25 @@ do
         "
         exit 1;
       fi
-      
+        
       if [ $hasPrefix = false ]; then
         message=$line;
       fi 
 
       # TODO: Check number of words in message
+      if [[ $(echo $message | wc -w) -le 4 ]]; then
+        echo "
+
+        Error: Message should be 5+ words (but really you should add as much detail as possible)
+
+        ";
+        exit 1;
+      fi
       # TODO: spellcheck?
     fi
     first=false;
   fi
 done < "$HUSKY_GIT_PARAMS"
+
+
+# TODO: Run tests unless prefix=wip (or message contains [skip-ci])?

--- a/scripts/hooks/commit-msg.sh
+++ b/scripts/hooks/commit-msg.sh
@@ -1,4 +1,6 @@
 #! /bin/bash
+# Hook after commit message is set. Reviews the message for a prefix (containing a `:`) that is valid
+# Valid prefixes are defined in `./.git-config.types`
 
 values=`cat .git-commit.types | tr '\n' '|' | sed 's/.$//'`;
 first=true;

--- a/scripts/hooks/commit-msg.sh
+++ b/scripts/hooks/commit-msg.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+while IFS= read -r line;
+do
+  echo "$line"
+done < "$HUSKY_GIT_PARAMS"

--- a/scripts/hooks/commit-msg.sh
+++ b/scripts/hooks/commit-msg.sh
@@ -2,7 +2,9 @@
 
 while IFS= read -r line;
 do
-  if [[ $line = #* ]]; then
+  if [[ $line = \#* ]]; then
+    continue;
+  elif [[ -z $line ]]; then
     continue;
   else
     echo "$line"

--- a/scripts/hooks/commit-msg.sh
+++ b/scripts/hooks/commit-msg.sh
@@ -1,5 +1,8 @@
 #! /bin/bash
 
+first=true;
+
+# Parse message from commit message file (location passed with $HUSKY_GIT_PARAMS)
 while IFS= read -r line;
 do
   if [[ $line = \#* ]]; then
@@ -7,6 +10,36 @@ do
   elif [[ -z $line ]]; then
     continue;
   else
-    echo "$line"
+    ## check that first line contains valid prefix
+    if [ $first = true ]; then
+      IFS=':' read -ra split <<< "$line";
+      prefix=${split[0]};
+      message=${split[1]};
+
+      hasPrefix=true;
+      # TODO: if $prefix has spaces hasPrefix=false; and request prefix/type from user
+
+      # Has prefix to check
+      if grep -q "$prefix" ".git-commit.types"; then
+        continue;
+      else
+        values=`cat .git-commit.types | tr '\n' '|' | sed 's/.$//'`;
+        echo "
+
+        Error: Unexpected commit message prefix - $prefix
+        Should be one of ($values)
+
+        "
+        exit 1;
+      fi
+      
+      if [ $hasPrefix = false ]; then
+        message=$line;
+      fi 
+
+      # TODO: Check number of words in message
+      # TODO: spellcheck?
+    fi
+    first=false;
   fi
 done < "$HUSKY_GIT_PARAMS"

--- a/scripts/hooks/commit-msg.sh
+++ b/scripts/hooks/commit-msg.sh
@@ -2,5 +2,9 @@
 
 while IFS= read -r line;
 do
-  echo "$line"
+  if [[ $line = #* ]]; then
+    continue;
+  else
+    echo "$line"
+  fi
 done < "$HUSKY_GIT_PARAMS"

--- a/scripts/hooks/prepare-commit-msg.sh
+++ b/scripts/hooks/prepare-commit-msg.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+echo $HUSKY_GIT_PARAMS;

--- a/scripts/hooks/prepare-commit-msg.sh
+++ b/scripts/hooks/prepare-commit-msg.sh
@@ -1,3 +1,11 @@
 #! /bin/bash
 
-echo $HUSKY_GIT_PARAMS;
+
+read -ra PARAM_ARRAY <<< "$HUSKY_GIT_PARAMS"
+
+if [ "${PARAM_ARRAY[1]}" == "template" ]; then
+  echo "nothing?";
+elif [ "${PARAM_ARRAY[1]}" == "message" ]; then
+  echo "TODO: ask type and prefix message with it";
+fi
+

--- a/scripts/hooks/prepare-commit-msg.sh
+++ b/scripts/hooks/prepare-commit-msg.sh
@@ -6,10 +6,11 @@ read -ra PARAM_ARRAY <<< "$HUSKY_GIT_PARAMS"
 set COMMIT_TYPE = "${PARAM_ARRAY[1]}"
 
 if [ "$COMMIT_TYPE" == "template" ]; then
-  echo "nothing?";
+  echo "Could ask type and save to prefix message with after added in editor";
 elif [ "$COMMIT_TYPE" == "message" ]; then
-  echo "TODO: ask type and prefix message with it";
+  echo "TODO: ask type and save to prefix message with";
 else
   echo $COMMIT_TYPE;
+  # during `--amend` this will be empty
 fi
 

--- a/scripts/hooks/prepare-commit-msg.sh
+++ b/scripts/hooks/prepare-commit-msg.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-
+# Githook that fires before message is received from user, we don't need this for now
 
 read -ra PARAM_ARRAY <<< "$HUSKY_GIT_PARAMS"
 
@@ -13,4 +13,3 @@ else
   echo $COMMIT_TYPE;
   # during `--amend` this will be empty
 fi
-

--- a/scripts/hooks/prepare-commit-msg.sh
+++ b/scripts/hooks/prepare-commit-msg.sh
@@ -3,9 +3,13 @@
 
 read -ra PARAM_ARRAY <<< "$HUSKY_GIT_PARAMS"
 
-if [ "${PARAM_ARRAY[1]}" == "template" ]; then
+set COMMIT_TYPE = "${PARAM_ARRAY[1]}"
+
+if [ "$COMMIT_TYPE" == "template" ]; then
   echo "nothing?";
-elif [ "${PARAM_ARRAY[1]}" == "message" ]; then
+elif [ "$COMMIT_TYPE" == "message" ]; then
   echo "TODO: ask type and prefix message with it";
+else
+  echo $COMMIT_TYPE;
 fi
 

--- a/templates.md
+++ b/templates.md
@@ -5,9 +5,10 @@
   - set config in .git/config
   - [..] hooks 
     - [..] check message after for commit-msg prefixes
-      - wip/fix/feat/feature/doc/poc/refactor/debt
+      - wip/fix/feat/feature/doc/refactor/debt/poc
     - TODO: check message for 7+ words after prefix
     - TODO: check message for spelling
-- [ ] Github Pull Request template
+    - Should we run tests if not wip?
+- [x] Github Pull Request template
 - [ ] Github Issue Templates
     - Feature/Fix/Tech-Debt/Refactor/POC/DOC

--- a/templates.md
+++ b/templates.md
@@ -1,0 +1,13 @@
+# Git Templates
+
+- [x] Commit Message
+  - added .git-commit.template
+  - set config in .git/config
+  - hooks TODO:
+    - if `-m` then ask for type
+    - check message after for commit-msg prefixes
+      - wip/fix/feat/feature/doc/poc/refactor/debt
+    - check message for 7+ words after prefix
+- [ ] Github Pull Request template
+- [ ] Github Issue Templates
+    - Feature/Fix/Tech-Debt/Refactor/POC/DOC

--- a/templates.md
+++ b/templates.md
@@ -3,10 +3,11 @@
 - [x] Commit Message
   - added .git-commit.template
   - set config in .git/config
-  - [ ] hooks (TODO):
-    - check message after for commit-msg prefixes
+  - [..] hooks 
+    - [..] check message after for commit-msg prefixes
       - wip/fix/feat/feature/doc/poc/refactor/debt
-    - check message for 7+ words after prefix
+    - TODO: check message for 7+ words after prefix
+    - TODO: check message for spelling
 - [ ] Github Pull Request template
 - [ ] Github Issue Templates
     - Feature/Fix/Tech-Debt/Refactor/POC/DOC

--- a/templates.md
+++ b/templates.md
@@ -4,11 +4,12 @@
   - added .git-commit.template
   - set config in .git/config
   - [..] hooks 
-    - [..] check message after for commit-msg prefixes
+    - [x] check message after for commit-msg prefixes
       - wip/fix/feat/feature/doc/refactor/debt/poc
-    - TODO: check message for 7+ words after prefix
-    - TODO: check message for spelling
-    - Should we run tests if not wip?
+      - attempted to request user input, but this is not really possible inside githook
+    - [x] check message for 5+ words after prefix
+    - [ ] check message for spelling
+    - [ ] Should we run tests if not wip?
 - [x] Github Pull Request template
-- [ ] Github Issue Templates
+- [x] Github Issue Templates
     - Feature/Fix/Tech-Debt/Refactor/POC/DOC

--- a/templates.md
+++ b/templates.md
@@ -3,8 +3,7 @@
 - [x] Commit Message
   - added .git-commit.template
   - set config in .git/config
-  - hooks TODO:
-    - if `-m` then ask for type
+  - [ ] hooks (TODO):
     - check message after for commit-msg prefixes
       - wip/fix/feat/feature/doc/poc/refactor/debt
     - check message for 7+ words after prefix


### PR DESCRIPTION
## :grey_question: Description
Started adding templates to the git repository
 - pull request template
 - issue templates
 - commit message template
    - started on hook to verify the commit message prefix from list in `./.git-commit.types`

also added check that message has word count at least 5 words

## :heavy_check_mark: Testing
Testing with invalid values (e.g. `wipa`) causes error
Testing with out a prefix causes error

Attempted to get user input after message was set if invalid prefix, but this is not supported by githooks. We can simply display an error message with the accepted types and fail the commit if it is invalid.

## :memo: Documentation
[Template Readme](https://github.com/devlinjunker/test.husky/compare/feature/templates?expand=1#diff-9052f6ca659538a7ad23c7f4f43faadc) created
Updated README.md

## :bulb: Issues
No Github issues, but this is practice using templates for git commit messages, issues, and pull requests

## :camera_flash: Visuals
![Screenshot 2019-12-22 20 44 23](https://user-images.githubusercontent.com/1504590/71336432-f8560680-24fb-11ea-8bd8-c3be749b781a.png)

![Screenshot 2019-12-22 20 44 47](https://user-images.githubusercontent.com/1504590/71336441-0441c880-24fc-11ea-81a2-73796b801c84.png)
